### PR TITLE
Encode SRI integrity hashes as standard base64

### DIFF
--- a/API.md
+++ b/API.md
@@ -245,7 +245,8 @@ async processDirectory()
 - Searches for files matching `inDirectory/*.inExtension`
 - Excludes files ending in `.11ty.js`
 - Calls `processFile()` for each file
-- In production: generates SHA-512 hash for cache busting and SRI
+- In production: generates SHA-512 hash for cache busting (base64url, truncated
+  to 10 characters) and for SRI (standard base64, as the SRI grammar requires)
 - In development: uses original filenames
 
 **Errors:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-23
+
 ### Fixed
 
 - Subresource Integrity hashes are now standard base64 rather than base64url, so
@@ -73,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For earlier version history, please see the [commit history](https://github.com/stephen-cox/eleventy-template-asset-pipeline/commits/main).
 
-[Unreleased]: https://github.com/stephen-cox/eleventy-template-asset-pipeline/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/stephen-cox/eleventy-template-asset-pipeline/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/stephen-cox/eleventy-template-asset-pipeline/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/stephen-cox/eleventy-template-asset-pipeline/compare/v0.2.2...v1.0.0
 [0.2.2]: https://github.com/stephen-cox/eleventy-template-asset-pipeline/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/stephen-cox/eleventy-template-asset-pipeline/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Subresource Integrity hashes are now standard base64 rather than base64url, so
+  browsers can parse them (Issue #25). The SRI grammar admits only standard
+  base64, so the previous base64url digests were discarded during parsing and the
+  integrity check was skipped entirely — assets were loaded with no verification.
+  Cache-busting filenames continue to use base64url, which is correct there.
+
+  **Behaviour change:** integrity checks are now actually enforced. If the bytes
+  a site serves differ from the bytes 11ty built — a CDN that recompresses or
+  rewrites assets, for example — those assets will now fail to load rather than
+  loading unverified.
+
 ## [1.0.0] - 2025-11-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,53 +55,71 @@ This file provides context for Claude (AI assistant) when working on this projec
 
 ```
 eleventy-template-asset-pipeline/
-├── index.js                      # Plugin entry point
+├── index.js                      # Plugin entry point (ESM)
+├── index.cjs                     # CommonJS wrapper
 ├── index.d.ts                    # TypeScript definitions (main)
-├── package.json                  # Package config (ES modules)
+├── package.json                  # Package config (ES modules, dual exports)
 ├── package-lock.json             # Lock file (committed)
 ├── ava.config.js                 # AVA test configuration
 ├── eslint.config.js              # ESLint configuration
 ├── .prettierrc.json              # Prettier configuration
+├── .prettierignore               # Prettier ignore
+├── .npmignore                    # Files excluded from the published package
 ├── README.md                     # User documentation
+├── API.md                        # API reference
+├── CHANGELOG.md                  # Keep a Changelog format
+├── CONTRIBUTING.md               # Contributor guide
+├── CLAUDE.md                     # This file - context for Claude
 ├── LICENSE                       # MIT License
 ├── .gitignore                    # Git ignore (node_modules only)
-├── claude.md                     # This file - context for Claude
 │
 ├── src/
 │   ├── ProcessAssets.js          # Core processing class
+│   ├── ProcessAssets.cjs         # CommonJS wrapper
 │   ├── ProcessAssets.d.ts        # TypeScript definitions
 │   └── shortcodes/
 │       ├── assetLink.js          # <link> tag generator
+│       ├── assetLink.cjs         # CommonJS wrapper
 │       ├── assetLink.d.ts        # TypeScript definitions
 │       ├── scriptLink.js         # <script> tag generator
+│       ├── scriptLink.cjs        # CommonJS wrapper
 │       └── scriptLink.d.ts       # TypeScript definitions
 │
-├── test/
-│   ├── ProcessAssets.test.js     # ProcessAssets tests (19 tests)
-│   ├── plugin.test.js            # Plugin config tests (10 tests)
+├── test/                         # 123 tests across 9 files
+│   ├── ProcessAssets.test.js         # ProcessAssets (14 tests)
+│   ├── error-handling.test.js        # ProcessAssets errors (23 tests)
+│   ├── plugin.test.js                # Plugin config (10 tests)
+│   ├── plugin-error-handling.test.js # Plugin errors (11 tests)
+│   ├── interop.test.js               # ESM/CJS interop (9 tests)
+│   ├── cjs-template-pattern.test.js  # CJS template usage (2 tests)
+│   ├── commonjs-usage.cjs            # CJS fixture for interop tests
+│   ├── example-template.11ty.cjs     # CJS template fixture
 │   ├── shortcodes/
-│   │   ├── assetLink.test.js     # assetLink tests (10 tests)
-│   │   └── scriptLink.test.js    # scriptLink tests (10 tests)
+│   │   ├── assetLink.test.js         # assetLink (10 tests)
+│   │   ├── scriptLink.test.js        # scriptLink (9 tests)
+│   │   └── error-handling.test.js    # Shortcode errors (35 tests)
 │   └── fixtures/
-│       ├── sample.css             # Test CSS file
-│       ├── sample.js              # Test JS file
+│       ├── sample.css                # Test CSS file
+│       ├── sample.js                 # Test JS file
 │       └── nested/
-│           └── nested.css         # For testing that nested files are ignored
+│           └── nested.css            # For testing that nested files are ignored
 │
-├── .github/
-│   ├── workflows/
-│   │   ├── test.yml              # GitHub Actions CI
-│   │   └── README.md             # Workflow documentation
-│   └── issues/                   # (if created)
+├── examples/                     # Working example projects (npm run test:examples)
+│   ├── postcss/                  # PostCSS pipeline
+│   ├── sass/                     # Sass pipeline
+│   ├── webpack/                  # Webpack pipeline
+│   ├── esbuild/                  # esbuild pipeline
+│   └── test-all.js               # Builds every example and checks output
 │
-└── .github-issues/                # Issue templates
-    ├── README.md
-    ├── 01-error-handling-validation.md
-    ├── 02-code-quality-improvements.md
-    ├── 03-typescript-support.md
-    ├── 04-enhanced-shortcode-flexibility.md
-    ├── 05-documentation-improvements.md
-    └── 06-additional-features.md
+├── .claude/
+│   └── commands/
+│       └── release.md            # /release - version bump, changelog, PR
+│
+└── .github/
+    └── workflows/
+        ├── test.yml              # GitHub Actions CI (test matrix)
+        ├── publish.yml           # NPM publish on merge to main
+        └── README.md             # Workflow documentation
 ```
 
 ## Important Technical Details
@@ -116,6 +134,21 @@ eleventy-template-asset-pipeline/
 2. **FIXED:** inDirectory array bug in ProcessAssets.js
    - Lines 40-45 wrapped in array, then line 46 overwrote it
    - Line 46 has been removed
+
+### Hash Encodings (two, deliberately different)
+
+Production builds hash the processed content once and encode that digest twice:
+
+- **Cache-busting filename** - `base64url`, truncated to 10 characters and
+  uppercased. Standard base64 can contain `/` and `+`, which are not safe in a
+  URL path segment.
+- **`integrity` attribute** - standard `base64`. The Subresource Integrity
+  grammar admits only standard base64, and browsers _silently ignore_ metadata
+  they cannot parse, so a base64url digest means no verification at all rather
+  than a failed check.
+
+Never collapse these back into one value (see issue #25, fixed in 1.1.0). Tests
+in `test/ProcessAssets.test.js` pin both encodings.
 
 ### Cross-Platform Considerations
 
@@ -151,8 +184,9 @@ module.exports = MyClass;
 
 **Test Organization:**
 
-- 41 total tests across 4 files
-- Each component has dedicated test file
+- 123 total tests across 9 files
+- Each component has dedicated test file, with error handling split out
+- ESM/CJS interop has its own tests plus `.cjs` fixtures
 - Tests cover success cases, error cases, edge cases
 - Cross-platform path handling required
 
@@ -162,6 +196,7 @@ module.exports = MyClass;
 npm test              # Run all tests once
 npm run test:watch    # Watch mode
 npx ava test/ProcessAssets.test.js  # Specific file
+npm run test:examples # Build every example project and check its output
 ```
 
 **Test Patterns:**
@@ -183,6 +218,13 @@ t.regex(file.path, /test\/fixtures\/sample\.css$/);
 - Tests on Ubuntu, Windows, macOS (9 combinations)
 - Uses `npm ci` (requires package-lock.json)
 - Status badge in README
+
+**Publishing** (`.github/workflows/publish.yml`):
+
+- Publishes to NPM when a release commit lands on `main`
+- Prepare releases with the `/release` command (`.claude/commands/release.md`):
+  clean tree, tests, lint, `npm version --no-git-tag-version`, changelog entry,
+  commit as `Release X.Y.Z`, then a PR
 
 **Requirements:**
 
@@ -288,16 +330,20 @@ autocomplete and type checking.
 ### Medium Priority
 
 4. ~~**No TypeScript definitions**~~ - FIXED: Complete TypeScript support added (issue #4)
-5. **scriptLink inflexible** - No custom attributes like assetLink
-6. **Duplicated code** - Collection filter logic repeated
+5. ~~**SRI hashes base64url encoded**~~ - FIXED: integrity now standard base64 (issue #25)
+6. **scriptLink inflexible** - No custom attributes like assetLink (accepts only
+   `{ throwOnMissing }`, while assetLink accepts arbitrary attributes)
+7. **Duplicated code** - Collection lookup and key-list logic repeated between
+   `assetLink.js` and `scriptLink.js`
 
 ### Low Priority (Nice to Have)
 
-7. **No source map support** - Would help debugging
-8. **Hardcoded SHA-512** - Could be configurable
-9. **Limited documentation** - Missing CHANGELOG, CONTRIBUTING, examples
+8. **No source map support** - Would help debugging
+9. **Hardcoded SHA-512** - Could be configurable (note: any change here must keep
+   the filename/integrity encodings separate)
 
-**See `.github-issues/` for detailed issue templates**
+**Open issues live on GitHub:**
+<https://github.com/stephen-cox/eleventy-template-asset-pipeline/issues>
 
 ## Working with This Codebase
 
@@ -508,8 +554,8 @@ git push origin branch      # Push to remote
 
 ---
 
-**Last Updated:** 2025-11-12
-**Plugin Version:** 0.2.1
+**Last Updated:** 2026-08-23
+**Plugin Version:** 1.1.0
 **Maintained By:** Stephen Cox <web@stephencox.net>
 
 ---
@@ -541,6 +587,10 @@ If any of these fail, DO NOT commit. Fix the issues first.
 
 **Recent Major Changes:**
 
+- 2026-08-23: Fixed SRI integrity hashes being base64url encoded, so browsers
+  ignored them entirely (issue #25) - released as 1.1.0
+- 2025-11-19: Released 1.0.0 with API reference, examples and troubleshooting docs
+- 2025-11-12: Added automated NPM publishing workflow and `/release` command
 - 2025-11-12: Added TypeScript type definitions (issue #4)
 - 2025-11-12: Added ESLint and Prettier for code quality
 - 2025-11-12: Established mandatory pre-commit checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,8 +381,11 @@ console.log("Found files:", files);
 **Debug hash generation:**
 
 ```javascript
-const hash = crypto.createHash("sha512").update(content).digest().toString("base64url");
-console.log("Hash:", hash.slice(0, 10));
+const sha512 = crypto.createHash("sha512").update(content);
+// base64url for the cache-busting filename; standard base64 for SRI (the SRI
+// grammar rejects base64url, and browsers silently ignore what they can't parse).
+console.log("Filename hash:", sha512.copy().digest("base64url").slice(0, 10));
+console.log("Integrity:", `sha512-${sha512.digest("base64")}`);
 ```
 
 ## Context for Common Questions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ t.regex(file.path, /test\/fixtures\/sample\.css$/);
 
 **Publishing** (`.github/workflows/publish.yml`):
 
-- Publishes to NPM when a release commit lands on `main`
+- Publishes to NPM (with provenance) when a GitHub Release is published from `main`
 - Prepare releases with the `/release` command (`.claude/commands/release.md`):
   clean tree, tests, lint, `npm version --no-git-tag-version`, changelog entry,
   commit as `Release X.Y.Z`, then a PR

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ This plugin uses [JavaScript templates](https://www.11ty.dev/docs/languages/java
 
 There are two ways to use this, either creating a JS template that loads and configures the ProcessAssets class or take advantage of the styles and scripts [Virtual Templates](https://www.11ty.dev/docs/virtual-templates/) provided by this plugin. In both cases it's necessary to provide an async function that takes the path to a file and returns a Promise with the compiled assets. This allows the use of tools such as PostCSS, Sass and Webpack as part of an Eleventy build without having to use a separate task runner such as Gulp.
 
+## Documentation
+
+- [API.md](API.md) - full API reference for the plugin, `ProcessAssets` and the shortcodes
+- [examples/](examples/) - working projects for PostCSS, Sass, Webpack and esbuild
+- [CHANGELOG.md](CHANGELOG.md) - release history
+- [CONTRIBUTING.md](CONTRIBUTING.md) - development setup and pull request process
+
 ## Module Support
 
 This package is published as an ES Module but includes full CommonJS interoperability through dual package exports. Both the main entry point and individual subpaths can be imported using either module system.
@@ -357,686 +364,112 @@ module.exports = ProcessAssetsPromise.then(
 );
 ```
 
-## Troubleshooting
+## Production builds
 
-### Cache-Busted Filename Mismatches
+Set `production: true` (usually from `process.env.ELEVENTY_ENV`) to enable cache
+busting and Subresource Integrity. Development builds skip both, so filenames
+stay stable and rebuilds stay fast.
 
-**Issue**: The generated cache-busted filename doesn't match the expected file in your template.
+In production each processed file is hashed with SHA-512 and the digest is used
+twice, in two different encodings:
 
-**Cause**: The plugin generates unique hashes based on file content, which change when the file changes.
-
-**Solution**:
-
-1. Use the `assetLink` or `scriptLink` shortcodes instead of hardcoding filenames
-2. Ensure your template is using the correct collection name
-3. Verify the asset key matches your source filename (without hash)
+- **Filename** - `main.css` becomes `main-ABC1234567.css`, using the first 10
+  characters of the base64url digest, uppercased. base64url avoids `+` and `/`,
+  which are not safe in a URL path.
+- **`integrity` attribute** - the full digest in standard base64, as the
+  [SRI specification](https://www.w3.org/TR/SRI/) requires. `assetLink` and
+  `scriptLink` add it along with `crossorigin="anonymous"` whenever it is
+  available.
 
 ```html
-<!-- ❌ Don't hardcode filenames -->
-<link href="/assets/css/main-ABC123.css" rel="stylesheet" />
-
-<!-- ✅ Use shortcodes instead -->
-{% assetLink collections._styles, 'main.css' %}
-```
-
-### Invalid processFile Configuration
-
-**Issue**: Error message "No processFile function configured" or processFile returns undefined.
-
-**Cause**: The processFile function is missing or not returning processed content.
-
-**Solution**:
-
-1. Ensure processFile is defined as an async function
-2. Make sure it returns the processed content as a string
-3. Check that the function is passed in the configuration
-
-```js
-// ✅ Correct processFile implementation
-async function processFile(file, production) {
-	const content = await fs.readFile(file, "utf-8");
-	// Process content here
-	return processedContent; // Must return a string
-}
-
-// Pass it to the configuration
-eleventyConfig.addPlugin(eleventyTemplateAssetPipeline, {
-	styles: {
-		enabled: true,
-		processFile: processFile, // Include this!
-		// ... other config
-	},
-});
-```
-
-### Permission Errors
-
-**Issue**: EACCES or EPERM errors when processing files.
-
-**Cause**: Insufficient permissions to read input files or write output files.
-
-**Solution**:
-
-1. Check file and directory permissions
-2. Ensure the output directory exists or can be created
-3. Verify you have write permissions in the output directory
-4. On Windows, check if files are locked by another process
-
-```bash
-# Check permissions (Unix/Linux/macOS)
-ls -la _assets/css
-
-# Create output directory if needed
-mkdir -p _site/_assets/css
-
-# Fix permissions (Unix/Linux/macOS)
-chmod -R 755 _assets
-```
-
-### Directory Not Found Errors
-
-**Issue**: Cannot find files in specified inDirectory.
-
-**Cause**: Path is incorrect or relative path is not resolved correctly.
-
-**Solution**:
-
-1. Use paths relative to your Eleventy project root
-2. Verify the directory exists
-3. Check for typos in the path
-4. Ensure you're not using `..` in paths (security restriction)
-
-```js
-// ✅ Correct - relative to project root
-inDirectory: "./_assets/css";
-
-// ❌ Incorrect - directory traversal not allowed
-inDirectory: "../../../css";
-```
-
-### Assets Not Appearing in Collections
-
-**Issue**: Collections are empty or missing expected assets.
-
-**Cause**: Collection name mismatch or files not being processed.
-
-**Solution**:
-
-1. Verify the collection name in your template matches the configuration
-2. Check that files exist in the inDirectory
-3. Ensure files have the correct extension (inExtension)
-4. Look for error messages in the build output
-
-```js
-// Configuration
-collection: "_styles"
-
-// Template - must match exactly
-{% assetLink collections._styles, 'main.css' %}
-```
-
-### PostCSS/Sass/Webpack Errors
-
-**Issue**: Build fails with CSS or JavaScript processing errors.
-
-**Cause**: Errors in your asset processing configuration or source files.
-
-**Solution**:
-
-1. Test your processFile function independently
-2. Check for syntax errors in your CSS/JS files
-3. Verify all required dependencies are installed
-4. Review your PostCSS/Webpack configuration
-5. Add try-catch blocks for better error messages
-
-```js
-async function processFile(file, production) {
-	try {
-		const css = await fs.readFile(file, "utf-8");
-		const result = await postcss(plugins).process(css, { from: file });
-		return result.css;
-	} catch (error) {
-		console.error(`Failed to process ${file}:`, error);
-		throw error; // Re-throw to see in Eleventy output
-	}
-}
-```
-
-## Performance
-
-### Development vs Production Mode
-
-The plugin optimizes differently for development and production environments:
-
-**Development Mode** (`production: false`):
-
-- No cache busting - files use original names
-- Faster builds - skips hash generation
-- No integrity hashes - reduces computation
-- Easier debugging - predictable filenames
-
-**Production Mode** (`production: true`):
-
-- Cache busting enabled - unique hashes in filenames
-- SRI hash generation - enhanced security
-- Optimized for deployment - long-term caching
-
-**Setting the Mode**:
-
-```js
-// Recommended: Use environment variable
-production: process.env.ELEVENTY_ENV === "production"
-
-// Build commands in package.json
-{
-	"scripts": {
-		"build": "ELEVENTY_ENV=production eleventy",
-		"dev": "eleventy --serve"
-	}
-}
-```
-
-### Optimization Techniques
-
-#### 1. Minimize processFile Overhead
-
-Keep your processFile function efficient:
-
-```js
-// ✅ Good - cache PostCSS plugins
-const postcssPlugins = [require("postcss-import"), require("autoprefixer")];
-
-async function processFile(file, production) {
-	const css = await fs.readFile(file, "utf-8");
-	return await postcss(postcssPlugins).process(css, { from: file });
-}
-
-// ❌ Bad - recreates plugins every time
-async function processFile(file, production) {
-	const css = await fs.readFile(file, "utf-8");
-	return await postcss([
-		require("postcss-import"), // Loaded on every file!
-		require("autoprefixer"),
-	]).process(css, { from: file });
-}
-```
-
-#### 2. Use Multiple Input Directories
-
-Process files from multiple sources efficiently:
-
-```js
-new ProcessAssets({
-	inDirectory: ["./_assets/css", "./node_modules/some-package/css"],
-	inExtension: "css",
-	// ... other config
-});
-```
-
-#### 3. Conditional Processing
-
-Apply different processing based on the environment:
-
-```js
-async function processFile(file, production) {
-	const css = await fs.readFile(file, "utf-8");
-
-	if (production) {
-		// Full optimization for production
-		return await postcss([require("postcss-import"), require("autoprefixer"), require("cssnano")])
-			.process(css, { from: file })
-			.then((r) => r.css);
-	} else {
-		// Minimal processing for development
-		return await postcss([require("postcss-import")])
-			.process(css, { from: file })
-			.then((r) => r.css);
-	}
-}
-```
-
-#### 4. Optimize Eleventy Build
-
-Combine with Eleventy's incremental builds:
-
-```bash
-# Development with watch mode
-eleventy --serve --incremental
-
-# Production build
-ELEVENTY_ENV=production eleventy
-```
-
-### Performance Tips
-
-1. **Limit File Processing**: Only process top-level files (the plugin already does this)
-2. **Use Import/Include**: Let your CSS/JS tools handle dependencies (e.g., `@import` in CSS)
-3. **Cache Dependencies**: Initialize tools outside processFile when possible
-4. **Async Operations**: Always use async/await for I/O operations
-5. **Monitor Build Times**: Use Eleventy's built-in performance diagnostics
-
-```bash
-# See detailed build performance
-DEBUG=Eleventy* eleventy
-```
-
-## Browser Compatibility
-
-### Subresource Integrity (SRI) Support
-
-The plugin generates SRI hashes in production mode for enhanced security.
-
-**Browser Support**:
-
-- Chrome/Edge: 45+
-- Firefox: 43+
-- Safari: 11.1+
-- Opera: 32+
-
-**Automatic SRI Implementation**:
-
-In production mode, the plugin automatically generates integrity hashes:
-
-```html
-<!-- Generated by assetLink -->
 <link
-	href="/assets/css/main-ABC123.css"
+	href="/assets/css/main-ABC1234567.css"
 	rel="stylesheet"
-	integrity="sha512-xyz..."
+	integrity="sha512-..."
 	crossorigin="anonymous"
 />
-
-<!-- Generated by scriptLink -->
-<script
-	src="/assets/js/app-DEF456.js"
-	integrity="sha512-abc..."
-	crossorigin="anonymous"
-	defer
-></script>
 ```
 
-The digest is a SHA-512 hash of the processed content, encoded as standard
-base64 as required by the [SRI specification](https://www.w3.org/TR/SRI/). This
-is deliberately different from the base64url encoding used for cache-busting
-filenames, where `+` and `/` would not be safe in a URL path.
+Because the browser enforces the integrity check, an asset whose served bytes
+differ from the bytes 11ty built will be blocked. If a CDN recompresses or
+rewrites your assets, configure it to serve them untouched.
 
-**Compatibility Considerations**:
-
-- SRI requires CORS configuration for cross-origin assets
-- The `crossorigin="anonymous"` attribute is automatically added
-- Older browsers ignore the integrity attribute (graceful degradation)
-- Integrity checks are enforced by the browser: if the bytes served differ from
-  the bytes 11ty built (for instance a CDN that recompresses or rewrites
-  assets), the asset will be blocked
-
-### ES Module Support
-
-The plugin supports both ES modules and CommonJS:
-
-**ES Modules (Recommended)**:
-
-```js
-import eleventyTemplateAssetPipeline from "@src-dev/eleventy-template-asset-pipeline";
-```
-
-**Browser Support**:
-
-- Chrome: 61+
-- Edge: 16+
-- Firefox: 60+
-- Safari: 11+
-
-**Fallback Strategy**:
-
-For broader browser support, use module/nomodule pattern:
-
-```html
-<!-- Modern browsers load this -->
-<script type="module" src="/assets/js/app.modern.js"></script>
-
-<!-- Legacy browsers load this -->
-<script nomodule src="/assets/js/app.legacy.js"></script>
-```
-
-### Cache Busting Compatibility
-
-Cache busting works in all browsers:
-
-- Uses filename-based hashing (universal support)
-- No browser-specific features required
-- Compatible with all CDNs and hosting platforms
-- Works with service workers and offline caching
-
-### CSS Features
-
-When using PostCSS or other processors, consider:
-
-**Autoprefixer**: Automatically adds vendor prefixes
-
-```js
-const postcssPlugins = [
-	require("autoprefixer")({
-		browsers: ["last 2 versions", "> 1%"],
-	}),
-];
-```
-
-**Custom Properties**: Consider fallbacks for older browsers
-
-```css
-/* Good practice with fallbacks */
-.element {
-	background: #333; /* Fallback */
-	background: var(--bg-color, #333);
-}
-```
-
-## Comparison with Alternatives
-
-### vs. Gulp
-
-**Gulp**:
-
-- Separate build process
-- Requires gulpfile configuration
-- More complex setup
-- Runs independently of Eleventy
-
-**This Plugin**:
-
-- Integrated with Eleventy build
-- Configured in `.eleventy.js`
-- Simpler setup for Eleventy projects
-- Single build command
-- Native access to Eleventy collections
-
-**When to use Gulp**:
-
-- Complex multi-step build processes
-- Legacy projects already using Gulp
-- Need for advanced task orchestration
-
-**When to use this plugin**:
-
-- Eleventy-focused projects
-- Prefer integrated build process
-- Want simpler configuration
-- Need tight Eleventy integration
-
-### vs. Grunt
-
-**Grunt**:
-
-- Task-based automation
-- Gruntfile configuration
-- Older, less actively maintained
-- Configuration over code
-
-**This Plugin**:
-
-- Code over configuration
-- Modern JavaScript/async-await
-- Actively maintained
-- Purpose-built for Eleventy
-
-**When to use Grunt**:
-
-- Existing Grunt infrastructure
-- Preference for configuration-based approach
-
-**When to use this plugin**:
-
-- Modern JavaScript projects
-- Eleventy-specific workflows
-- Active development and support
-
-### vs. Eleventy Assets Plugin
-
-**Eleventy Assets Plugin**:
-
-- Different approach to asset handling
-- May have different features
-
-**This Plugin**:
-
-- JavaScript template-based approach
-- Virtual template support
-- Built-in cache busting
-- SRI hash generation
-- Flexible processFile function
-- Dual module system support
-
-**Advantages of this plugin**:
-
-1. **Flexibility**: Use any asset processor (PostCSS, Sass, Webpack, esbuild)
-2. **Security**: Automatic SRI hash generation
-3. **Performance**: Built-in cache busting
-4. **Integration**: Native Eleventy collections
-5. **Modern**: ES modules and CommonJS support
-
-### vs. Manual Asset Pipeline
-
-**Manual Approach**:
-
-- Separate npm scripts for CSS/JS
-- Manual cache busting
-- Custom shortcode creation
-- Multiple build steps
-
-**This Plugin**:
-
-- Single integrated build
-- Automatic cache busting
-- Built-in shortcodes
-- Unified configuration
-
-**Manual Build Example**:
-
-```json
-{
-	"scripts": {
-		"build:css": "postcss src/css -d dist/css",
-		"build:js": "webpack",
-		"build:eleventy": "eleventy",
-		"build": "npm run build:css && npm run build:js && npm run build:eleventy"
-	}
-}
-```
-
-**With This Plugin**:
-
-```json
-{
-	"scripts": {
-		"build": "eleventy"
-	}
-}
-```
-
-**Advantages of this plugin**:
-
-1. **Simplicity**: Single build command
-2. **Consistency**: Everything in `.eleventy.js`
-3. **Reliability**: No manual coordination needed
-4. **Features**: Cache busting and SRI included
-5. **Maintenance**: Less configuration to manage
-
-### Migration Guide
-
-#### From Gulp/Grunt
-
-1. Identify your asset processing tasks
-2. Convert task functions to processFile functions
-3. Move configuration to `.eleventy.js`
-4. Remove gulp/grunt dependencies
-5. Update build scripts
-
-#### From Manual Pipeline
-
-1. Install this plugin
-2. Create processFile function from your existing scripts
-3. Configure plugin in `.eleventy.js`
-4. Replace custom shortcodes with built-in ones
-5. Simplify package.json scripts
+Reference the hashed files through the shortcodes rather than hardcoding paths -
+the filename changes whenever the content does.
 
 ## Contributing and Releases
 
-### Development
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. In short: fork,
+branch, and make sure `npm test`, `npm run lint` and `npm run format:check` all
+pass before opening a pull request against `main`.
 
-When contributing to this project:
-
-1. Fork the repository and create a feature branch
-2. Make your changes and ensure all tests pass: `npm test`
-3. Run linting: `npm run lint` (or `npm run lint:fix` to auto-fix)
-4. Check formatting: `npm run format:check` (or `npm run format` to auto-fix)
-5. Submit a pull request to the `main` branch
-
-### Publishing Releases
-
-This package uses automated NPM publishing via GitHub Actions. To publish a new version:
-
-1. **Update the version** in `package.json`:
-
-   ```bash
-   npm version patch  # For bug fixes (0.2.1 -> 0.2.2)
-   npm version minor  # For new features (0.2.1 -> 0.3.0)
-   npm version major  # For breaking changes (0.2.1 -> 1.0.0)
-   ```
-
-2. **Push the changes** to the main branch:
-
-   ```bash
-   git push origin main
-   ```
-
-3. **Create a GitHub Release**:
-   - Go to the [Releases page](https://github.com/stephen-cox/eleventy-template-asset-pipeline/releases)
-   - Click "Draft a new release"
-   - Create a new tag matching the version in `package.json` (e.g., `0.2.2`)
-   - Target the `main` branch
-   - Add release notes describing the changes
-   - Click "Publish release"
-
-4. **Automated Publishing**:
-   - GitHub Actions will automatically run tests and linting
-   - If all checks pass, the package will be published to NPM with provenance
-   - The workflow status can be monitored in the [Actions tab](https://github.com/stephen-cox/eleventy-template-asset-pipeline/actions)
-
-**Important Notes:**
-
-- Only releases from the `main` branch will be published to NPM
-- The version in `package.json` must match the release tag
-- All tests and linting must pass before publishing
-- NPM packages are published with provenance for supply chain security
+Releases are published to NPM by GitHub Actions, with provenance, when a GitHub
+Release is published from `main`. Bump the version and update
+[CHANGELOG.md](CHANGELOG.md) first, then create the release with a tag matching
+`package.json`.
 
 ## Error Handling
 
 The plugin includes comprehensive error handling and input validation to help identify configuration issues and provide helpful error messages.
 
-### Configuration Validation
+### Configuration errors
 
-The plugin validates all configuration parameters and provides descriptive error messages when issues are detected:
+Required parameters are validated up front, and paths are checked for directory
+traversal:
 
 ```js
-// Example: Missing required parameters
-eleventyConfig.addPlugin(eleventyTemplateAssetPipeline, {
-	styles: {
-		enabled: true,
-		inDirectory: "./_assets/css",
-		// Missing: inExtension, outDirectory, outExtension
-	},
-});
+new ProcessAssets({ inDirectory: "./_assets/css" });
 // Error: Missing required configuration parameters: inExtension, outDirectory, outExtension.
 // ProcessAssets requires: inDirectory, inExtension, outDirectory, outExtension.
-// Example: { inDirectory: "./_assets/css", inExtension: "css", outDirectory: "_assets/css", outExtension: "css" }
-```
 
-### Path Sanitization
-
-The plugin automatically sanitizes file paths to prevent directory traversal attacks:
-
-```js
-// Example: Directory traversal attempt
-new ProcessAssets({
-	inDirectory: "../../../etc/passwd", // This will throw an error
-	inExtension: "css",
-	outDirectory: "_assets/css",
-	outExtension: "css",
-});
+new ProcessAssets({ inDirectory: "../../../etc/passwd", ... });
 // Error: Invalid config.inDirectory: Directory traversal not allowed.
 // Path "../../../etc/passwd" contains ".." after normalization.
-// Use absolute paths or paths relative to your project root.
 ```
 
-### ProcessFile Validation
+A missing `processFile`, or one that returns `null` or `undefined`, is reported
+the same way.
 
-The plugin ensures that the `processFile` function is properly defined and returns valid content:
+### Shortcode errors
 
-```js
-// Example: Missing processFile function
-const processor = new ProcessAssets({
-	inDirectory: "./_assets/css",
-	inExtension: "css",
-	outDirectory: "_assets/css",
-	outExtension: "css",
-	// processFile is not defined
-});
+Missing assets warn and render nothing, so one bad reference does not fail the
+build:
 
-await processor.processDirectory();
-// Error: No processFile function configured.
-// Provide a processFile function in the configuration:
-// { processFile: async (filePath, isProduction) => { /* process and return content */ } }
-```
-
-### Shortcode Error Handling
-
-The shortcodes (`assetLink` and `scriptLink`) validate their inputs and provide helpful error messages:
-
-```js
-// Example: Asset not found
+```njk
 {% assetLink collections._styles, 'nonexistent.css' %}
-// Warning: Asset "nonexistent.css" not found in collection.
-// Available keys: main.css, theme.css
-// Returns: '' (empty string)
+{# Warning: Asset "nonexistent.css" not found in collection. #}
+{# Available keys: main.css, theme.css #}
+{# Returns: '' #}
 ```
 
-For stricter error handling, you can enable the `throwOnMissing` option:
+Pass `throwOnMissing: true` to turn that warning into an error instead - useful
+during development, or in CI where a silently missing stylesheet is worse than a
+failed build:
 
-```js
-// In your template
+```njk
 {% assetLink collections._styles, 'nonexistent.css', {}, { throwOnMissing: true } %}
-// Error: Asset "nonexistent.css" not found in collection.
-// Available keys: main.css, theme.css
 ```
 
-### Type Checking
-
-All function parameters are type-checked with helpful error messages:
+Parameter types are checked too, and the message shows the expected usage:
 
 ```js
-// Example: Invalid parameter type
 assetLink(123, "main.css");
 // Error: assetLink collection must be an array or iterable, received number.
 // Pass a collection from Eleventy: assetLink(collections._styles, "main.css")
 ```
 
-### File Processing Errors
+### File processing errors
 
-When file processing fails, the error includes context about which file failed and why:
+Errors thrown by your `processFile` function are wrapped with the file that
+failed:
 
 ```js
-// Example: ProcessFile throws an error
-async function processFile(file, production) {
-	throw new Error("PostCSS compilation failed");
-}
-
-// During build:
 // Error: Failed to process file "./_assets/css/main.css".
 // Error: PostCSS compilation failed.
 // Check that the file exists and the processFile function is working correctly.
 ```
 
-### Best Practices for Error Handling
+### Best practices
 
 1. **Always provide all required configuration parameters** to avoid configuration errors
 2. **Use try-catch blocks** around your `processFile` function to provide meaningful error messages
@@ -1044,7 +477,7 @@ async function processFile(file, production) {
 4. **Enable strict mode** (`throwOnMissing: true`) during development to catch missing assets early
 5. **Check the console** for warnings about missing assets or empty directories
 
-### Common Error Messages
+### Common error messages
 
 | Error Message                               | Cause                                        | Solution                                                         |
 | ------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -655,11 +655,19 @@ In production mode, the plugin automatically generates integrity hashes:
 ></script>
 ```
 
+The digest is a SHA-512 hash of the processed content, encoded as standard
+base64 as required by the [SRI specification](https://www.w3.org/TR/SRI/). This
+is deliberately different from the base64url encoding used for cache-busting
+filenames, where `+` and `/` would not be safe in a URL path.
+
 **Compatibility Considerations**:
 
 - SRI requires CORS configuration for cross-origin assets
 - The `crossorigin="anonymous"` attribute is automatically added
 - Older browsers ignore the integrity attribute (graceful degradation)
+- Integrity checks are enforced by the browser: if the bytes served differ from
+  the bytes 11ty built (for instance a CDN that recompresses or rewrites
+  assets), the asset will be blocked
 
 ### ES Module Support
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -204,7 +204,8 @@ Each example can be customized:
 
 ## Common Issues
 
-See the main [README Troubleshooting section](../README.md#troubleshooting) for common issues and solutions.
+See the [Error Handling section](../README.md#error-handling) of the main README
+for the errors the plugin raises and what they mean.
 
 ## Additional Resources
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@src-dev/eleventy-template-asset-pipeline",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@src-dev/eleventy-template-asset-pipeline",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"glob": "^11.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@src-dev/eleventy-template-asset-pipeline",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Eleventy plugin to provide asset pipelines as part of the 11ty build process.",
 	"type": "module",
 	"main": "index.cjs",

--- a/src/ProcessAssets.d.ts
+++ b/src/ProcessAssets.d.ts
@@ -71,6 +71,9 @@ export interface ProcessedAsset {
 
 	/**
 	 * Subresource integrity hash (only in production builds).
+	 *
+	 * Formatted as `sha512-<digest>`, where the digest is standard base64 as
+	 * required by the Subresource Integrity specification.
 	 */
 	integrity?: string;
 }

--- a/src/ProcessAssets.js
+++ b/src/ProcessAssets.js
@@ -261,17 +261,24 @@ class ProcessAssets {
 						// Production build.
 						if (this.production) {
 							try {
-								// Add hash of the content to destination file name for cache busting.
-								const sha512 = crypto.createHash("sha512");
-								const hash = sha512.update(content).digest().toString("base64url");
-								const destination = `${basename}-${hash.slice(0, 10).toUpperCase()}.${this.outExtension}`;
+								const sha512 = crypto.createHash("sha512").update(content);
+
+								// base64url for the cache-busting filename: standard base64 can
+								// contain "/" and "+", which are not safe in a URL path segment.
+								const filenameHash = sha512.copy().digest("base64url");
+								// Standard base64 for the integrity attribute: the Subresource
+								// Integrity grammar admits only standard base64, and browsers
+								// silently ignore metadata they cannot parse.
+								const integrityHash = sha512.digest("base64");
+
+								const destination = `${basename}-${filenameHash.slice(0, 10).toUpperCase()}.${this.outExtension}`;
 
 								files.push({
 									index: filename,
 									source: file,
 									destination: `${this.outDirectory}/${destination}`,
 									content: content,
-									integrity: `sha512-${hash}`,
+									integrity: `sha512-${integrityHash}`,
 								});
 							} catch (error) {
 								throw new Error(

--- a/test/ProcessAssets.test.js
+++ b/test/ProcessAssets.test.js
@@ -123,6 +123,52 @@ test("ProcessAssets.processDirectory() - generates cache-busting filenames in pr
 	t.regex(files[0].integrity, /^sha512-/);
 });
 
+test("ProcessAssets.processDirectory() - integrity hash is standard base64, not base64url", async (t) => {
+	const processor = new ProcessAssets({
+		inDirectory: "./test/fixtures",
+		inExtension: "css",
+		outDirectory: "_assets/css",
+		outExtension: "css",
+		processFile: simpleProcessFile,
+		production: true,
+	});
+
+	const files = await processor.processDirectory();
+	const digest = files[0].integrity.replace(/^sha512-/, "");
+
+	// The Subresource Integrity grammar only admits standard base64, so a digest
+	// containing base64url's "-" or "_" is discarded and the check is skipped.
+	t.regex(digest, /^[A-Za-z0-9+/]+={0,2}$/);
+	t.is(digest.length, 88);
+
+	// It must match the SHA-512 of the bytes actually written out.
+	const crypto = await import("crypto");
+	const expected = crypto.createHash("sha512").update(files[0].content).digest("base64");
+	t.is(digest, expected);
+});
+
+test("ProcessAssets.processDirectory() - cache-busting filename stays URL safe", async (t) => {
+	const processor = new ProcessAssets({
+		inDirectory: "./test/fixtures",
+		inExtension: "css",
+		outDirectory: "_assets/css",
+		outExtension: "css",
+		processFile: simpleProcessFile,
+		production: true,
+	});
+
+	const files = await processor.processDirectory();
+	const crypto = await import("crypto");
+	const filenameHash = crypto
+		.createHash("sha512")
+		.update(files[0].content)
+		.digest("base64url")
+		.slice(0, 10)
+		.toUpperCase();
+
+	t.is(files[0].destination, `_assets/css/sample-${filenameHash}.css`);
+});
+
 test("ProcessAssets.processDirectory() - skips .11ty.js files", async (t) => {
 	const fs = await import("fs");
 	const testFile = "./test/fixtures/test.11ty.js";


### PR DESCRIPTION
The Subresource Integrity grammar admits only standard base64, so the
base64url digests emitted in production were discarded during parsing.
Unparseable integrity metadata is ignored rather than rejected, so every
asset carrying an integrity attribute was loaded with no verification at
all — silently, since the markup looked correct and the console stayed
quiet.

- Derive the filename slice and the integrity value from separate
  digests of the same hash: base64url for the cache-busting filename
  (where "+" and "/" are unsafe in a URL path), standard base64 for the
  integrity attribute
- Add regression tests asserting the integrity digest matches
  /^[A-Za-z0-9+/]+={0,2}$/, is 88 characters, and equals the SHA-512 of
  the emitted content, plus a test pinning the URL-safe filename hash
- Document the two encodings in README, API.md and the type definitions

Behaviour change for consumers: integrity checks are now enforced, so
sites whose served bytes differ from their built bytes (a CDN that
recompresses or rewrites assets, for instance) will start seeing those
assets blocked. Noted in the changelog.

Fixes #25

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WmiLdj1fAnB5M69R7uJ5fW