### PR TITLE
Publish with an NPM token again, and check it before building

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -172,27 +172,34 @@ Publishes the package to NPM when a GitHub Release is published from `main`.
 The workflow re-runs the tests and linting against `main`, checks that the
 release tag matches `package.json`, then publishes.
 
-Authentication uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers):
-the job requests an OIDC token from GitHub and npm exchanges it for a
-short-lived credential. There is no `NPM_TOKEN` secret to expire or rotate, and
-provenance is attached automatically.
+Authentication uses the `NPM_TOKEN` repository secret. It must be a granular
+access token created on npmjs.com with **read and write** access to
+`@src-dev/eleventy-template-asset-pipeline` (or to the `@src-dev` scope).
 
-This requires a one-off setup on npmjs.com. On the package page, under
-Settings -> Trusted Publisher, add a GitHub Actions publisher with:
+Two settings have to agree for a token publish to succeed. If either is wrong
+the registry answers `403 Forbidden` - the same response it gives for an expired
+token, so check both before assuming the token is stale:
 
-- Organization or user: `stephen-cox`
-- Repository: `eleventy-template-asset-pipeline`
-- Workflow filename: `publish.yml`
+- **The token.** Granular access tokens expire; npm caps their lifetime, so a
+  token that worked for the last release may simply have run out. Read-only
+  tokens, and tokens whose package list does not include this package, are also
+  refused.
+- **The package.** On npmjs.com under Settings -> Publishing access, the package
+  must allow automation tokens. If it is set to require two-factor
+  authentication on every publish, no CI token can publish it.
 
-If that entry is missing or does not match, the registry rejects the publish
-with `403 Forbidden` after the tarball has been built.
+The job runs `npm whoami` before building the tarball so a bad credential fails
+early with a clear message rather than as a bare 403 at the end.
 
-Two constraints are easy to trip over when editing this workflow:
+`id-token: write` is granted to the publish job because `--provenance` needs it.
 
-- The publish job needs `id-token: write`; without it there is no OIDC token to
-  exchange.
-- Trusted publishing needs npm 11.5.1 or newer, which is why the job upgrades
-  npm before publishing rather than using the version bundled with Node.
+The long-term fix for expiring tokens is
+[trusted publishing](https://docs.npmjs.com/trusted-publishers), where npm
+exchanges the job's OIDC token for a short-lived credential and no secret is
+stored at all. Enabling it requires completing 2FA on npmjs.com to add a trusted
+publisher entry for this repository and `publish.yml`. Worth switching to when
+that is possible; the workflow then drops `NODE_AUTH_TOKEN` and `--provenance`
+(provenance becomes automatic) and needs npm 11.5.1 or newer.
 
 ## Future Workflows
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,10 +80,9 @@ jobs:
     needs: [test, lint]
     runs-on: ubuntu-latest
 
-    # Trusted publishing: npm exchanges this job's OIDC token for a short-lived
-    # credential, so there is no NPM_TOKEN to expire, leak or rotate. The
-    # package must list this repository and workflow as a trusted publisher on
-    # npmjs.com, otherwise the registry rejects the publish with 403.
+    # id-token is for provenance only. Publishing authenticates with the
+    # NPM_TOKEN secret, which must be a granular access token with read and
+    # write access to @src-dev/eleventy-template-asset-pipeline.
     permissions:
       contents: read
       id-token: write
@@ -101,14 +100,26 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
-      # Node 22 ships npm 10.x; trusted publishing needs npm 11.5.1 or newer.
-      - name: Upgrade npm
-        run: |
-          npm install -g npm@latest
-          npm --version
-
       - name: Install dependencies
         run: npm ci
+
+      # Fail here, with a usable message, rather than with a bare 403 after the
+      # tarball has been built and the provenance statement signed.
+      - name: Check NPM credentials
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "Error: the NPM_TOKEN secret is empty or missing."
+            exit 1
+          fi
+          if ! NPM_USER=$(npm whoami 2>&1); then
+            echo "Error: NPM_TOKEN did not authenticate with the registry."
+            echo "npm said: $NPM_USER"
+            echo "Generate a new granular access token on npmjs.com and update the NPM_TOKEN secret."
+            exit 1
+          fi
+          echo "Authenticated as: $NPM_USER"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Extract version from release tag
         id: get_version
@@ -130,10 +141,10 @@ jobs:
             exit 1
           fi
 
-      # Provenance is generated automatically when publishing via trusted
-      # publishing, so --provenance is not passed here.
       - name: Publish to NPM
-        run: npm publish --access public
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish summary
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,9 +222,12 @@ t.regex(file.path, /test\/fixtures\/sample\.css$/);
 **Publishing** (`.github/workflows/publish.yml`):
 
 - Publishes to NPM (with provenance) when a GitHub Release is published from `main`
-- Authenticates with npm trusted publishing (OIDC), not an `NPM_TOKEN` secret:
-  the publish job needs `id-token: write`, npm 11.5.1+, and a matching trusted
-  publisher entry on npmjs.com. A mismatch fails with `403 Forbidden`.
+- Authenticates with the `NPM_TOKEN` secret: a granular access token with write
+  access to the package. These expire, and npm answers `403 Forbidden` for an
+  expired token, a read-only token and a package that requires 2FA on every
+  publish alike - see `.github/workflows/README.md` before assuming which.
+  Trusted publishing (OIDC) would remove the secret entirely but needs 2FA on
+  npmjs.com to enable.
 - Prepare releases with the `/release` command (`.claude/commands/release.md`):
   clean tree, tests, lint, `npm version --no-git-tag-version`, changelog entry,
   commit as `Release X.Y.Z`, then a PR

--- a/README.md
+++ b/README.md
@@ -406,6 +406,6 @@ pass before opening a pull request against `main`.
 Releases are published to NPM by GitHub Actions, with provenance, when a GitHub
 Release is published from `main`. Bump the version and update
 [CHANGELOG.md](CHANGELOG.md) first, then create the release with a tag matching
-`package.json`. Publishing authenticates through npm trusted publishing rather
-than a token - see [.github/workflows/README.md](.github/workflows/README.md) for 
-the setup it depends on.
+`package.json`. Publishing authenticates with the `NPM_TOKEN` secret - see
+[.github/workflows/README.md](.github/workflows/README.md) for what that token
+needs and what to check when a publish is rejected.


### PR DESCRIPTION
Trusted publishing needs a trusted publisher entry added on npmjs.com, which is gated behind 2FA that is not currently reachable, so go back to token authentication:

- Restore NODE_AUTH_TOKEN and --provenance on the publish step, and drop the npm upgrade that only trusted publishing needed
- Keep id-token: write scoped to the publish job, now for provenance
- Add a credential preflight: an empty secret or a token npm rejects fails at npm whoami with an actionable message, instead of as a bare 403 after the tarball is built and the provenance signed
- Document what the token needs, and that an expired token, a read-only token and a package requiring 2FA on every publish all present as the same 403, so all three are worth checking

Keeps a note on trusted publishing as the eventual fix for tokens that expire on npm's schedule.


Claude-Session: https://claude.ai/code/session_01WmiLdj1fAnB5M69R7uJ5fW